### PR TITLE
Explode refactors

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,15 +26,15 @@ class TestWithMocks:
             show_progress=True,
         )
 
-    def test_vcf_explode_init(self):
+    def test_vcf_dexplode_init(self):
         runner = ct.CliRunner(mix_stderr=False)
-        with mock.patch("bio2zarr.vcf.explode_init") as mocked:
+        with mock.patch("bio2zarr.vcf.explode_init", return_value=5) as mocked:
             result = runner.invoke(
-                cli.vcf2zarr, ["explode-init", "source", "dest", "-n", "5"], catch_exceptions=False
+                cli.vcf2zarr, ["dexplode-init", "source", "dest", "5"], catch_exceptions=False
             )
             assert result.exit_code == 0
-            assert len(result.stdout) == 0
             assert len(result.stderr) == 0
+            assert result.stdout == "5\n"
             mocked.assert_called_once_with(
                 ("source",),
                 "dest",
@@ -43,22 +43,11 @@ class TestWithMocks:
                 show_progress=True,
             )
 
-    def test_vcf_explode_partition_count(self):
-        runner = ct.CliRunner(mix_stderr=False)
-        with mock.patch("bio2zarr.vcf.explode_partition_count", return_value=5) as mocked:
-            result = runner.invoke(
-                cli.vcf2zarr, ["explode-partition-count", "path"], catch_exceptions=False
-            )
-            assert result.exit_code == 0
-            assert result.stdout == "5\n"
-            assert len(result.stderr) == 0
-            mocked.assert_called_once_with("path")
-
-    def test_vcf_explode_slice(self):
+    def test_vcf_dexplode_slice(self):
         runner = ct.CliRunner(mix_stderr=False)
         with mock.patch("bio2zarr.vcf.explode_slice") as mocked:
             result = runner.invoke(
-                cli.vcf2zarr, ["explode-slice", "path", "-s", "1", "-e", "2"], catch_exceptions=False
+                cli.vcf2zarr, ["dexplode-slice", "path", "-s", "1", "-e", "2"], catch_exceptions=False
             )
             assert result.exit_code == 0
             assert len(result.stdout) == 0
@@ -72,11 +61,11 @@ class TestWithMocks:
                 show_progress=True,
             )
 
-    def test_vcf_explode_finalise(self):
+    def test_vcf_dexplode_finalise(self):
         runner = ct.CliRunner(mix_stderr=False)
         with mock.patch("bio2zarr.vcf.explode_finalise") as mocked:
             result = runner.invoke(
-                cli.vcf2zarr, ["explode-finalise", "path"], catch_exceptions=False
+                cli.vcf2zarr, ["dexplode-finalise", "path"], catch_exceptions=False
             )
             assert result.exit_code == 0
             assert len(result.stdout) == 0

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -791,9 +791,10 @@ def test_split_explode(tmp_path):
         "tests/data/vcf/sample.vcf.gz.3.split/X.vcf.gz",
     ]
     out = tmp_path / "test.explode"
-    pcvcf = vcf.explode_init(paths, out, target_num_partitions=15)
-    assert pcvcf.num_partitions == 3
-    assert vcf.explode_partition_count(out) == 3
+    num_partitions = vcf.explode_init(paths, out, target_num_partitions=15)
+    assert num_partitions == 3
+
+    pcvcf = vcf.PickleChunkedVcf.load(out)
 
     with pytest.raises(ValueError):
         vcf.explode_slice(out, -1, 3)


### PR DESCRIPTION
Various refactoring and documentation. The main invocation now returns this:

```
$ python3 -m bio2zarr vcf2zarr
Usage: python -m bio2zarr vcf2zarr [OPTIONS] COMMAND [ARGS]...

  Convert VCF file(s) to the vcfzarr format.

  The simplest usage is:

  $ vcf2zarr convert [VCF_FILE] [ZARR_PATH]

  This will convert the indexed VCF (or BCF) into the vcfzarr format in a
  single step. As this writes the intermediate columnar format to a temporary
  directory, we only recommend this approach for small files (< 1GB, say).

  The recommended approach is to run the conversion in two passes, and to keep
  the intermediate columnar format ("exploded") around to facilitate
  experimentation with chunk sizes and compression settings:

  $ vcf2zarr explode [VCF_FILE_1] ... [VCF_FILE_N] [ICF_PATH]
  $ vcf2zarr encode [ICF_PATH] [ZARR_PATH]

  The inspect command provides a way to view contents of an exploded ICF or
  Zarr:

  $ vcf2zarr inspect [PATH]

  This is useful when tweaking chunk sizes and compression settings to suit
  your dataset, using the mkschema command and --schema option to encode:

  $ vcf2zarr mkschema [ICF_PATH] > schema.json
  $ vcf2zarr encode [ICF_PATH] [ZARR_PATH] --schema schema.json

  By editing the schema.json file you can drop columns that are not of
  interest and edit column specific compression settings. The --max-variant-
  chunks option to encode allows you to try out these options on small
  subsets, hopefully arriving at settings with the desired balance of
  compression and query performance.

  ADVANCED USAGE

  For very large datasets (terabyte scale) it may be necessary to distribute
  the explode and encode steps across a cluster:

  $ vcf2zarr dexplode-init [VCF_FILE_1] ... [VCF_FILE_N] [ICF_PATH] [NUM_PARTITIONS]
  $ vcf2zarr dexplode-slice [ICF_PATH] [START] [STOP]
  $ vcf2zarr dexplode-finalise [ICF_PATH]

  See the online documentation at [FIXME] for more details on distributed
  explode.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  convert            Convert input VCF(s) directly to vcfzarr (not...
  inspect            Inspect an intermediate format or Zarr path.
  explode            Convert VCF(s) to columnar intermediate format
  mkschema           Generate a schema for zarr encoding
  encode             Encode intermediate columnar format (see explode) to...
  dexplode-init      Initial step for parallel conversion of VCF(s) to...
  dexplode-slice     Convert VCF(s) to columnar intermediate format
  dexplode-finalise  Final step for parallel conversion of VCF(s) to...
  validate           Development only, do not use.
```

Main changes:

- make new commands ``dexplode-init`` etc, to try and distinguish from single "explode" operation
- Made ``dexplode-init`` output the actual number of partitions, and removed ``count-partitions`` option.

I'm also trying to standardise the language around "intermediate columnar format (ICF)", which I think is a helpful way of describing it.

@benjeffery @shz9 it would be great if you could take a look at this CLI help-text, and see if you spot any issues.
