### PR TITLE
Refactor intermediate format stuff

### DIFF
--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -108,8 +108,8 @@ def dexplode_init(vcfs, icf_path, num_partitions, verbose, worker_processes):
 
 @click.command
 @click.argument("path", type=click.Path(), required=True)
-@click.option("-s", "--start", type=int, required=True)
-@click.option("-e", "--end", type=int, required=True)
+@click.argument("start", type=int)
+@click.argument("end", type=int)
 @verbose
 @worker_processes
 @column_chunk_size

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ class TestWithMocks:
         runner = ct.CliRunner(mix_stderr=False)
         with mock.patch("bio2zarr.vcf.explode_slice") as mocked:
             result = runner.invoke(
-                cli.vcf2zarr, ["dexplode-slice", "path", "-s", "1", "-e", "2"], catch_exceptions=False
+                cli.vcf2zarr, ["dexplode-slice", "path", "1", "2"], catch_exceptions=False
             )
             assert result.exit_code == 0
             assert len(result.stdout) == 0

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -794,7 +794,8 @@ def test_split_explode(tmp_path):
     num_partitions = vcf.explode_init(paths, out, target_num_partitions=15)
     assert num_partitions == 3
 
-    pcvcf = vcf.PickleChunkedVcf.load(out)
+    with pytest.raises(FileNotFoundError):
+        pcvcf = vcf.PickleChunkedVcf(out)
 
     with pytest.raises(ValueError):
         vcf.explode_slice(out, -1, 3)
@@ -803,7 +804,7 @@ def test_split_explode(tmp_path):
 
     vcf.explode_slice(out, 0, 3)
     vcf.explode_finalise(out)
-    pcvcf = vcf.PickleChunkedVcf.load(out)
+    pcvcf = vcf.PickleChunkedVcf(out)
     assert pcvcf.columns['POS'].vcf_field.summary.asdict() == {
         'num_chunks': 3,
         'compressed_size': 587,


### PR DESCRIPTION
Part way through refactoring the columnar intermediate format.

Main changes:

- Create a "wip" directory that we put stuff in while the thing is being written to (removed on success)
- Make a dedicated "Writer" class, which deals with all the creation stuff, so then the PickleChunkedVcf class is just for doing read-work.

Next up, rename the class to "ColumnarIntermediateFormat" and move all this intermediate format based stuff into its own module. I think we can then finalise the on-disk metadata format, and get ready to support going forward.